### PR TITLE
Set ReadTimeout to fix delay issues with reading serial data

### DIFF
--- a/source/USBSerial.cpp
+++ b/source/USBSerial.cpp
@@ -460,6 +460,11 @@ UsbSerial::connectToDeviceAsync(
         _serial_device->BaudRate = _baud;
         _serial_device->IsDataTerminalReadyEnabled = true;
 
+		// Fix for delayed serial response
+		Windows::Foundation::TimeSpan readTimeoutSpan;
+		readTimeoutSpan.Duration = 30000L;
+		_serial_device->ReadTimeout = readTimeoutSpan;
+
         switch (_config) {
         case SerialConfig::SERIAL_5E1:
             _serial_device->DataBits = 5;


### PR DESCRIPTION
In my testing with the remote-wiring code I found that there were 6-7 second delays in getting a digital pin report that seemed to be coming from the Serial over USB communication. After much digging and searching I found that if I set the ReadTimeout on the SerialDevice object to something low (like 30 msec) then I get fantastic response time.

I originally reported this under the remote-wiring repo so check that out for more details on what I was seeing: [remote-wiring issue 103](https://github.com/ms-iot/remote-wiring/issues/103).

Let me know if you need any other testing or changes.
